### PR TITLE
Steps for onboarding Azure/static-web-apps-deploy  to the healthdashboard 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report---feature-request.md
@@ -1,0 +1,9 @@
+---
+name: Bug Report / Feature Request
+about: Create a report to help us improve
+title: ''
+labels: need-to-triage
+assignees: ''
+
+---
+

--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -1,0 +1,35 @@
+name: setting-default-labels
+
+# Controls when the action will run. 
+on:
+  schedule:
+  - cron: "0 0/3 * * *"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps: 
+      - uses: actions/stale@v3
+        name: Setting issue as idle
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is idle because it has been open for 14 days with no activity.'
+          stale-issue-label: 'idle'
+          days-before-stale: 14
+          days-before-close: -1
+          operations-per-run: 100
+          exempt-issue-labels: 'backlog'
+          
+      - uses: actions/stale@v3
+        name: Setting PR as idle
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR is idle because it has been open for 14 days with no activity.'
+          stale-pr-label: 'idle'
+          days-before-stale: 14
+          days-before-close: -1
+          operations-per-run: 100


### PR DESCRIPTION
Ace-crew is currently looking after onboarding this action to the [health dashboad](https://azure.github.io/actions/health-dashboard.html). As a prerequisite we want to ensure enabling and adding certain things for this.

1. Default issue_template which adds `need-to-triage` label for a new incoming issue.
2. defaultLabels.yml workflow which adds `idle` label to PRs and issues which are more than 14 days old.
3. Adding [standard set of labels ](https://github.com/Azure/actions/blob/main/docs/onboarding-to-dashboard.md#steps-to-follow-to-onboard-an-action-on-the-health-dashboard).

In this PR we are doing 1,2 but the 3rd one need to be done from the maintainer side. 