### PR TITLE
Add skip_deploy_on_missing_secrets input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   skip_app_build:
     description: "Skips the build step for the application source code if set to true."
     required: false
+  skip_deploy_on_missing_secrets:
+     description: "Skips the deployment step when the required secrets are missing if set to true."
+     required: false
   config_file_location:
     description: "Directory location where the staticwebapp.config.json file can be found in the source code"
     required: false


### PR DESCRIPTION
To avoid build warnings like:

```
Warning: Unexpected input(s) 'skip_deploy_on_missing_secrets', valid inputs are ['entryPoint', 'args', 'action', 'app_location', 'azure_static_web_apps_api_token', 'api_build_command', 'api_location', 'app_artifact_location', 'output_location', 'app_build_command', 'repo_token', 'routes_location', 'skip_app_build']
```

Reference: https://github.com/microsoftgraph/microsoft-graph-explorer-v4/runs/3322794009?check_suite_focus=true#step:4:1