### PR TITLE
Use docker image directly in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,4 +36,5 @@ outputs:
     description: "Url of the application"
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://mcr.microsoft.com/appsvc/staticappsclient:latest"
+  entrypoint: "/entrypoint.sh"


### PR DESCRIPTION
Using the Static Web Apps docker image directly will ensure that the image stays up to date on self-hosted GitHub runners. 