### PR TITLE
Updated action to use docker image directly and removed unnecessary files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM mcr.microsoft.com/appsvc/staticappsclient:stable
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ outputs:
   static_web_app_url:
     description: "Url of the application"
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  image: "docker://mcr.microsoft.com/appsvc/staticappsclient:stable"
+  entrypoint: "/entrypoint.sh"

--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,6 @@ outputs:
   static_web_app_url:
     description: "Url of the application"
 runs:
+  using: "docker"
   image: "docker://mcr.microsoft.com/appsvc/staticappsclient:stable"
   entrypoint: "/entrypoint.sh"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh -l
-cd /bin/staticsites/
-./StaticSitesClient $INPUT_ACTION


### PR DESCRIPTION
As part of supporting self-hosted runners, we now directly reference the StaticWebApps docker image rather than using an intermediate Docker file. This enables GitHub to automatically pull the most recent version of the image for self-hosted runners. 